### PR TITLE
fix silent error on Connection.printFiles()

### DIFF
--- a/cupsconnection.c
+++ b/cupsconnection.c
@@ -4866,7 +4866,7 @@ Connection_printFiles (Connection *self, PyObject *args, PyObject *kwds)
 						   settings);
   Connection_end_allow_threads (self);
 
-  if (jobid < 0) {
+  if (jobid == 0) {
     cupsFreeOptions (num_settings, settings);
     free (title);
     free_string_list (num_filenames, filenames);


### PR DESCRIPTION
cupsPrintFiles2 returns a 0 job-id on error, which is correctly handled in
printFile() but not in printFiles(). This patch fixes that.