### PR TITLE
Fix connection.printFiles options parsing

### DIFF
--- a/cupsconnection.c
+++ b/cupsconnection.c
@@ -4714,7 +4714,7 @@ Connection_printFiles (Connection *self, PyObject *args, PyObject *kwds)
     }
 
     num_settings = cupsAddOption (UTF8_from_PyObj (&name, key),
-				  UTF8_from_PyObj (&value, key),
+				  UTF8_from_PyObj (&value, val),
 				  num_settings,
 				  &settings);
     free (name);


### PR DESCRIPTION
Looking at how options parsing for `Connection_printFile` was implemented, seems like there was a typo in `Connection_printFiles` method.

Fixed that, but didn't test tbh.