### PR TITLE
Add basic CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+---
+version: 2.1
+jobs:
+  cheese-shop:
+    machine:
+      image: ubuntu-2204:2023.02.1
+    steps:
+      - run: "pip install pycups"
+  run-tests:
+    machine:
+      image: ubuntu-2204:2023.02.1
+    steps:
+      - checkout
+      - run: "make"
+      - run: "sudo make install"
+      - run: "python3 test.py"
+workflows:
+  main-workflow:
+    jobs:
+      - run-tests
+      - cheese-shop


### PR DESCRIPTION
Add a bare-bones CircleCI configuration that,
- runs test.py
- checks that the cheese shop currently has an installable version.

CircleCI costs $0 for open-source projects and is pretty good. I notice that this project has no CI in place, and if it did I would not have spent so much time working out how to [install it](https://github.com/OpenPrinting/pycups/issues/50).

Could do with some fleshing out so I'm open to suggestions.